### PR TITLE
Fix spelling error in library-combo manpage.

### DIFF
--- a/Documentation/library-combo.7
+++ b/Documentation/library-combo.7
@@ -17,7 +17,7 @@ option. With library combinations we mean the Objective-C runtime, the Foundatio
 .PP
 If you installed your
 .B GNUstep
-system in a non-flattened way all system dependend binaries are installed in subdirectories with
+system in a non-flattened way all system dependent binaries are installed in subdirectories with
 .I cpu/os/library-combo
 information. That means for instance that the
 .I gnustep-base


### PR DESCRIPTION
Fix spelling error.  This was fixed in the Debian package in 2017 by Eric Heintzmann.