### PR TITLE
Fix spelling error in gnustep-config manpage.

### DIFF
--- a/Documentation/gnustep-config.1
+++ b/Documentation/gnustep-config.1
@@ -13,7 +13,7 @@ gnustep-config \- prints information about the current gnustep installation.
 can print information about the currently installed GNUstep system. Output
 is generated dynamically based on environment variables such as
 GNUSTEP_CONFIG_FILE and GNUSTEP_MAKEFILES,
-though default values for these are generated when the tool is configured/installed.  Output is primarily the locations in which various GNUstep resources are installed, but also provide flags used to build differnt types of GNUstep project.
+though default values for these are generated when the tool is configured/installed.  Output is primarily the locations in which various GNUstep resources are installed, but also provide flags used to build different types of GNUstep project.
 .SH OPTIONS
 .TP
 .BI \-\-variable= variable


### PR DESCRIPTION
Fix spelling error.  This was fixed in the Debian package in 2017 by Eric Heintzmann.