### PR TITLE
configure, TestFramework: Generated gnustep-tests binary will now be executable out-of-the-box.

### DIFF
--- a/configure
+++ b/configure
@@ -11287,7 +11287,7 @@ printf "%s\n" "$as_me: executing $ac_file commands" >&6;}
 
 
   case $ac_file$ac_mode in
-    "default":C) chmod a+x openapp opentool fixpath.sh executable.template ;;
+    "default":C) chmod a+x openapp opentool fixpath.sh executable.template TestFramework/gnustep-tests ;;
 
   esac
 done # for ac_tag

--- a/configure.ac
+++ b/configure.ac
@@ -1841,6 +1841,6 @@ gnustep-make.spec gnustep-config TestFramework/gnustep-tests
 filesystem.make filesystem.sh filesystem.csh gnustep-make-ld.so.conf])
 AC_CONFIG_FILES([runtime/$OBJC_RUNTIME_LIB.make:config.make.in])
 AC_CONFIG_COMMANDS([default],
-	[[chmod a+x openapp opentool fixpath.sh executable.template]],
+	[[chmod a+x openapp opentool fixpath.sh executable.template TestFramework/gnustep-tests]],
 	[[]])
 AC_OUTPUT


### PR DESCRIPTION
File `TestFramework/gnustep-tests` is generated by `configure` from `TestFramework/gnustep-tests.in`.

It looks like this file is intended to be executable, even though it makes little difference since it is unlikely to be usable until installed.