### PR TITLE
Enable weak-style references in "ng" configuration

### DIFF
--- a/library-combo.make
+++ b/library-combo.make
@@ -50,7 +50,7 @@ ifeq ($(OBJC_RUNTIME_LIB), ng)
      RUNTIME_VERSION=gnustep-2.2
    endif
   endif
-  RUNTIME_FLAG = -fobjc-runtime=$(RUNTIME_VERSION) -fblocks
+  RUNTIME_FLAG = -fobjc-runtime=$(RUNTIME_VERSION) -fblocks -fobjc-weak
   RUNTIME_DEFINE = -DGNUSTEP_RUNTIME=1 -D_NONFRAGILE_ABI=1
 endif
 


### PR DESCRIPTION
Currently, all code emulating weak references by just not retaining it is essentially UB when interfacing with ARC. The clang flag enables the use of '__weak' in non-ARC translation units.