### PR TITLE
Add support to gnustep-config for uikit-libs

### DIFF
--- a/Documentation/gnustep-config.1
+++ b/Documentation/gnustep-config.1
@@ -7,7 +7,7 @@ gnustep-config \- prints information about the current gnustep installation.
 .SH SYNOPSIS
 .BR gnustep-config " ["
 .BI \-\-variable= variable
-.RB | \-\-objc-flags | \-\-objc-libs | \-\-base-libs | \-\-gui-libs " ]"
+.RB | \-\-objc-flags | \-\-objc-libs | \-\-base-libs | \-\-gui-libs | \-\-uikit-libs " ]"
 .SH DESCRIPTION
 .B gnustep-config
 can print information about the currently installed GNUstep system. Output
@@ -73,6 +73,10 @@ prints all the flags required to link a command-line ObjC program (no gui)
 .TP
 .B \-\-gui-libs
 prints all the flags required to link a GUI ObjC program
+
+.TP
+.B \-\-uikit-libs
+prints all the flags required to link a UIKit ObjC program
 .SH BUGS
 None known
 .SH SEE ALSO

--- a/gnustep-config.in
+++ b/gnustep-config.in
@@ -39,6 +39,7 @@ case "$1" in
   --objc-libs)  ;;
   --base-libs)  ;;
   --gui-libs)   ;;
+  --uikit-libs) ;;
   --host-dir) ;;
   --host-ldir) ;;
   --installation-domain-for=*) ;;
@@ -103,6 +104,8 @@ if [ "$1" = "--help" ]; then
     echo
     echo "--gui-libs: prints all the flags required to link a GUI ObjC program"
     echo 
+    echo "--uikit-libs: prints all the flags required to link a UIKit ObjC program"
+    echo
     echo "--host-dir: prints the host architecture name"
     echo 
     echo "--host-ldir: prints the host architecture and library combo name"
@@ -203,6 +206,8 @@ case "$1" in
   --base-libs) @GNUMAKE@ --no-print-directory -s -f "$GNUSTEP_MAKEFILES/empty.make" print-gnustep-make-base-libs quiet=yes 2>/dev/null
               exit 0;;
   --gui-libs) @GNUMAKE@ --no-print-directory -s -f "$GNUSTEP_MAKEFILES/empty.make" print-gnustep-make-gui-libs quiet=yes 2>/dev/null
+              exit 0;;
+  --uikit-libs) @GNUMAKE@ --no-print-directory -s -f "$GNUSTEP_MAKEFILES/empty.make" print-gnustep-make-uikit-libs quiet=yes 2>/dev/null
               exit 0;;
   --host-dir) @GNUMAKE@ --no-print-directory -s -f "$GNUSTEP_MAKEFILES/empty.make" print-gnustep-make-host-dir quiet=yes 2>/dev/null
               exit 0;;

--- a/rules.make
+++ b/rules.make
@@ -772,6 +772,7 @@ endif
         print-gnustep-make-objc-libs \
         print-gnustep-make-base-libs \
         print-gnustep-make-gui-libs \
+        print-gnustep-make-uikit-libs \
         print-gnustep-make-installation-domain \
         print-gnustep-make-host-dir \
         print-gnustep-make-host-ldir \
@@ -814,6 +815,10 @@ print-gnustep-make-base-libs:
 # Flags used when linking against Foundation and GUI
 print-gnustep-make-gui-libs:
 	@(echo $(ALL_LDFLAGS) $(CC_LDFLAGS) $(ALL_LIB_DIRS) $(ADDITIONAL_GUI_LIBS) $(AUXILIARY_GUI_LIBS) $(GUI_LIBS) $(BACKEND_LIBS) $(ADDITIONAL_TOOL_LIBS) $(AUXILIARY_TOOL_LIBS) $(FND_LIBS) $(ADDITIONAL_OBJC_LIBS) $(AUXILIARY_OBJC_LIBS) $(OBJC_LIBS) $(SYSTEM_LIBS) $(TARGET_SYSTEM_LIBS))
+
+# Flags used when linking against Foundation and UIKit
+print-gnustep-make-uikit-libs:
+	@(echo $(ALL_LDFLAGS) $(CC_LDFLAGS) $(ALL_LIB_DIRS) $(UIKIT_LIBS) $(ADDITIONAL_TOOL_LIBS) $(AUXILIARY_TOOL_LIBS) $(FND_LIBS) $(ADDITIONAL_OBJC_LIBS) $(AUXILIARY_OBJC_LIBS) $(OBJC_LIBS) $(SYSTEM_LIBS) $(TARGET_SYSTEM_LIBS))
 
 print-gnustep-make-installation-domain:
 	@(echo $(GNUSTEP_INSTALLATION_DOMAIN))


### PR DESCRIPTION
This PR makes the changes for supporting the "libs-uikit" library so that when building we can get the list of libraries needed from gnustep-config like with other libraries.